### PR TITLE
Setup Zram in antiX and start/stop toggle menu in Bento antiX.

### DIFF
--- a/Zram-antiX/Makefile
+++ b/Zram-antiX/Makefile
@@ -1,0 +1,107 @@
+# Makefile for ZRAM_antiX
+#
+# Variables
+DESTDIR ?= /
+PREFIX = /usr/local
+INITD_DIR = /etc/init.d
+DEFAULT_DIR = /etc/default
+APPS_DIR = /usr/share/applications
+
+# Files to install
+INIT_SCRIPT = etc/init.d/zram
+DEFAULT_CONF = etc/default/zram
+GUI_SCRIPT = usr/local/bin/toggle-zram-gui.sh
+DESKTOP_FILE = usr/share/applications/zram-control.desktop
+POST_INSTALL_SCRIPT = post-install
+
+# Target directories
+INSTALL_INITD_DIR = $(DESTDIR)$(INITD_DIR)
+INSTALL_DEFAULT_DIR = $(DESTDIR)$(DEFAULT_DIR)
+INSTALL_GUI_DIR = $(DESTDIR)$(PREFIX)/bin
+INSTALL_APPS_DIR = $(DESTDIR)$(APPS_DIR)
+
+.PHONY: all install uninstall clean help
+
+all:
+	@echo "Type 'make install' to install ZRAM control scripts and configuration."
+	@echo "Type 'make uninstall' to remove them."
+
+install: directories copy_files permissions register_service update_db clean_polkit
+
+directories:
+	@echo "Creating installation directories..."
+	mkdir -p $(INSTALL_INITD_DIR)
+	mkdir -p $(INSTALL_DEFAULT_DIR)
+	mkdir -p $(INSTALL_GUI_DIR)
+	mkdir -p $(INSTALL_APPS_DIR)
+
+copy_files:
+	@echo "Copying files..."
+	cp $(INIT_SCRIPT) $(INSTALL_INITD_DIR)/zram
+	cp $(DEFAULT_CONF) $(INSTALL_DEFAULT_DIR)/zram
+	cp $(GUI_SCRIPT) $(INSTALL_GUI_DIR)/toggle-zram-gui.sh
+	cp $(DESKTOP_FILE) $(INSTALL_APPS_DIR)/zram-control.desktop
+
+permissions:
+	@echo "Setting file permissions..."
+	chmod 755 $(INSTALL_INITD_DIR)/zram
+	chmod 755 $(INSTALL_GUI_DIR)/toggle-zram-gui.sh
+	# Configuration file and desktop file don't need executable bits
+	chmod 644 $(INSTALL_DEFAULT_DIR)/zram
+	chmod 644 $(INSTALL_APPS_DIR)/zram-control.desktop
+
+register_service:
+	@echo "Registering ZRAM service with update-rc.d..."
+	$(DESTDIR)$(POST_INSTALL_SCRIPT) # Execute your existing post-install script
+
+update_db:
+	@echo "Updating desktop database..."
+	update-desktop-database $(INSTALL_APPS_DIR) # Specify directory for safety
+
+clean_polkit:
+	@echo "Cleaning up Polkit rule for gksu..."
+	rm -f $(DESTDIR)/etc/polkit-1/rules.d/05-zram-no-root-password.rules
+	@if [ -x "$(DESTDIR)/usr/lib/polkit-1/polkitd" ]; then \
+	    echo "Restarting Polkit daemon..."; \
+	    $(DESTDIR)/usr/lib/polkit-1/polkitd --no-debug & \
+	else \
+	    echo "Polkit daemon not found, skipping restart."; \
+	fi
+
+uninstall: unregister_service remove_files clean_polkit_uninstall update_db
+	@echo "Uninstallation complete. You may need to reboot or log out/in."
+
+unregister_service:
+	@echo "Unregistering ZRAM service with update-rc.d..."
+	update-rc.d zram remove || true # '|| true' to avoid error if not registered
+
+remove_files:
+	@echo "Removing installed files..."
+	rm -f $(INSTALL_INITD_DIR)/zram
+	rm -f $(INSTALL_DEFAULT_DIR)/zram
+	rm -f $(INSTALL_GUI_DIR)/toggle-zram-gui.sh
+	rm -f $(INSTALL_APPS_DIR)/zram-control.desktop
+
+clean_polkit_uninstall:
+	@echo "Cleaning up Polkit rule during uninstall..."
+	# This should ideally be done by the post-install/post-remove script of the package
+	# but added here for completeness if manual uninstall.
+	rm -f $(DESTDIR)/etc/polkit-1/rules.d/05-zram-no-root-password.rules
+	@if [ -x "$(DESTDIR)/usr/lib/polkit-1/polkitd" ]; then \
+	    echo "Restarting Polkit daemon..."; \
+	    $(DESTDIR)/usr/lib/polkit-1/polkitd --no-debug & \
+	else \
+	    echo "Polkit daemon not found, skipping restart."; \
+	fi
+
+help:
+	@echo "Makefile for ZRAM_antiX project."
+	@echo ""
+	@echo "Usage:"
+	@echo "  make install     - Installs ZRAM scripts, configuration, and desktop entry."
+	@echo "  make uninstall   - Removes ZRAM components."
+	@echo "  make clean       - (No files to clean for this project)"
+	@echo ""
+	@echo "To install to a specific root directory (for packaging):"
+	@echo "  make install DESTDIR=/path/to/staging/root"
+

--- a/Zram-antiX/etc/default/zram
+++ b/Zram-antiX/etc/default/zram
@@ -1,0 +1,10 @@
+# This is the /etc/default/zram file containing the %age 
+# of available ram you want to use to define the size 
+# of the zram block devices. 
+# See http://code.google.com/p/compcache/w/list
+# 25% for the configuration file should work for most
+# computers.
+# Exemple zram default configuration:
+FACTOR=50
+
+

--- a/Zram-antiX/etc/init.d/zram
+++ b/Zram-antiX/etc/init.d/zram
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -x
+### BEGIN INIT INFO
+# Provides: zram
+# Required-Start: $local_fs
+# Required-Stop:
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: Increased Performance In Linux With zRam (Virtual Swap Compressed in RAM)
+# Description: Adapted from systemd scripts at https://github.com/mystilleef/FedoraZram
+# Included as part of antix-goodies package by anticapitalista <antiX@operamail.com>
+# This script was written by tradetaxfree from http://crunchbanglinux.org/forums modified with the 
+# contributions from mimas in 2012 and captnfab <f+debian@chezlefab.net> in 2012 and 2013 (debian-facile.org community). 
+# Copy this script (as root) from /usr/local/bin to /etc/init.d and then #update-rc.d zram defaults
+# After booting verify the module is loaded with: lsmod | grep zram
+### END INIT INFO
+
+
+start() {
+    # get the number of CPUs
+    num_cpus=$(grep -c processor /proc/cpuinfo)
+    # if something goes wrong, assume we have 1
+    [ "$num_cpus" != 0 ] || num_cpus=1
+
+    # set decremented number of CPUs
+    last_cpu=$((num_cpus - 1))
+    
+    #default Factor % = 90 change this value here or create /etc/default/zram
+    #FACTOR=90
+    #& put the above single line in /etc/default/zram with the value you want
+	[ -f /etc/default/zram ] && source /etc/default/zram || true
+	factor=$FACTOR # percentage
+
+    # get the amount of memory in the machine
+     memtotal=$(grep MemTotal /proc/meminfo | sed 's/[^0-9]\+//g')
+    mem_by_cpu=$((memtotal * factor * 1024 / num_cpus / 100))
+
+    # load dependency modules
+    # kernels 3.4 onwards
+# The following command line allows the system to detect and use the appropriate 
+# parameter supported by a kernel:
+# See https://aur.archlinux.org/packages/zramswap/?comments=all
+# Comment by dront78 (2012-08-31 09:59) 
+/sbin/modprobe zram $(/sbin/modinfo zram | grep -E -o '(num_devices|zram_num_devices)')=$num_cpus
+
+    if [ $? -gt 0 ]; then
+      echo -e "Your Kernel needs to be compiled with ZRAM support:" \
+      "\n\nDevice Drivers --> Staging Drivers --> Compressed RAM block device support (M)" \
+      "\nDevice Drivers --> Staging Drivers --> Dynamic compression of swap pages and clean pagecache pages (*)" \
+      "\n\nThe Liquorix Kernel (http://liquorix.net) has ZRAM support built in."
+      exit 1
+    fi
+    echo "zram devices probed successfully"
+    
+    # initialize the devices
+    for i in $(seq 0 $last_cpu); do
+    echo $mem_by_cpu > /sys/block/zram$i/disksize
+    # Creating swap filesystems
+    /sbin/mkswap /dev/zram$i
+    # Switch the swaps on
+    /sbin/swapon -p 100 /dev/zram$i
+    done
+}
+
+stop() {
+    # get the number of CPUs
+    num_cpus=$(grep -c processor /proc/cpuinfo)
+
+    # set decremented number of CPUs
+    last_cpu=$((num_cpus - 1))
+
+    # Switching off swap
+    for i in $(seq 0 $last_cpu); do
+    if [ "$(grep /dev/zram$i /proc/swaps)" != "" ]; then
+    /sbin/swapoff /dev/zram$i
+    sleep 1
+    fi
+    done
+
+    sleep 1
+    rmmod zram
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart)
+        stop
+        sleep 3
+        start
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart}"
+        RETVAL=1
+esac
+exit $RETVAL
+

--- a/Zram-antiX/post-install
+++ b/Zram-antiX/post-install
@@ -1,0 +1,3 @@
+#!/bin/sh
+update-rc.d zram defaults
+

--- a/Zram-antiX/usr/local/bin/toggle-zram-gui.sh
+++ b/Zram-antiX/usr/local/bin/toggle-zram-gui.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+#
+# ZRAM control script with YAD graphical interface.
+# Uses gksu for authentication.
+# Displays final status based on actual ZRAM state.
+#
+# Debugging lines - Uncomment two next lines to debug
+# REMOVE THESE LINES AFTER DEBUGGING IF NOT NEEDED ANYMORE!
+#set -x # Enable command tracing
+#exec > /tmp/toggle-zram-gui-debug.log 2>&1 # Redirect all output to a log file
+# End Debugging lines
+
+ZRAM_INIT_SCRIPT="/etc/init.d/zram"
+
+# Function to display final status messages (success or error) with Yad and notify-send.
+# This message will require an OK click to close, as it's a final status report.
+# Usage: show_final_message <type> <title> <text>
+show_final_message() {
+    local type="$1"
+    local title="$2"
+    local text="$3"
+    local icon=""
+
+    case "$type" in
+        info) icon="dialog-information" ;;
+        error) icon="dialog-error" ;;
+        *) icon="dialog-information" ;; # Default
+    esac
+
+    notify-send --expire-time=5000 --icon="$icon" "$title" "$text" 2>/dev/null &
+    yad --title="$title" --text="$text" --image="$icon" --button=OK:0 --center &
+}
+
+# Function to display temporary messages that close automatically.
+# Usage: show_temporary_message <type> <title> <text> <timeout_seconds>
+show_temporary_message() {
+    local type="$1"
+    local title="$2"
+    local text="$3"
+    local timeout_seconds="$4"
+    local icon=""
+
+    case "$type" in
+        info) icon="dialog-information" ;;
+        error) icon="dialog-error" ;;
+        *) icon="dialog-information" ;; # Default
+    esac
+
+    notify-send --expire-time=3000 --icon="$icon" "$title" "$text" 2>/dev/null &
+    yad --title="$title" --text="$text" --image="$icon" --timeout=$timeout_seconds --no-buttons --center &
+}
+
+
+# --- Script Execution Start ---
+
+# Check if gksu is installed
+if ! command -v gksu &> /dev/null; then
+    show_final_message error "Error" "gksu is not installed. Please install it to use this script."
+    exit 1
+fi
+
+# Check if the ZRAM init script exists
+if [ ! -f "${ZRAM_INIT_SCRIPT}" ]; then
+    show_final_message error "ZRAM Error" "ZRAM init script not found at ${ZRAM_INIT_SCRIPT}."
+    exit 1
+fi
+
+# Main script logic based on arguments
+case "$1" in
+    start|stop)
+        # These declarations are NOT 'local' because they are at the top level
+        # of this case block, not inside a function.
+        action_verb="$1"
+        action_past_participle=""
+
+        if [ "$action_verb" = "start" ]; then
+            action_past_participle="started"
+        else
+            action_past_participle="stopped"
+        fi
+
+        # Display a temporary message while the operation is in progress
+        show_temporary_message info "ZRAM Control" "Attempting to ${action_verb} ZRAM..." 3
+
+        # Execute the command with gksu. gksu will display its own password prompt.
+        # We redirect stdout/stderr to a temporary log file for potential debugging,
+        # but we will primarily rely on /proc/swaps for status.
+        temp_log="/tmp/zram_gksu_output.log"
+        gksu "${ZRAM_INIT_SCRIPT}" "$action_verb" > "$temp_log" 2>&1
+        gksu_command_status=$? # Status of gksu command itself
+
+        # Check the actual state of ZRAM after the command execution
+        zram_active=$(cat /proc/swaps | grep -c "/dev/zram") # Count active zram devices
+
+        # Determine success/failure based on actual ZRAM state
+        if [ "$action_verb" = "start" ]; then
+            if [ "$zram_active" -gt 0 ]; then
+                show_final_message info "ZRAM Control" "ZRAM ${action_past_participle} successfully."
+            else
+                # If ZRAM is not active after a 'start' command, it's a failure.
+                show_final_message error "ZRAM Error" "Failed to ${action_verb} ZRAM. Gksu status: $gksu_command_status. Check logs for details: $temp_log"
+            fi
+        elif [ "$action_verb" = "stop" ]; then
+            if [ "$zram_active" -eq 0 ]; then
+                show_final_message info "ZRAM Control" "ZRAM ${action_past_participle} successfully."
+            else
+                # If ZRAM is still active after a 'stop' command, it's a failure.
+                show_final_message error "ZRAM Error" "Failed to ${action_verb} ZRAM. Gksu status: $gksu_command_status. Check logs for details: $temp_log"
+            fi
+        fi
+
+        # Clean up temporary log file
+        rm -f "$temp_log"
+        ;;
+    *)
+        # The main YAD menu (if the script is called without start/stop arguments).
+        # This one must remain in the foreground as it's the main interactive form.
+        yad --form --title="ZRAM Control" --text="Choose an action for ZRAM." \
+            --field="Start ZRAM":fbtn "bash -c '${0} start'" \
+            --field="Stop ZRAM":fbtn "bash -c '${0} stop'" \
+            --button="Close:1" \
+            --center --fixed --width=300 --height=150
+        ;;
+esac
+
+exit 0

--- a/Zram-antiX/usr/share/applications/zram-control.desktop
+++ b/Zram-antiX/usr/share/applications/zram-control.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=ZRAM Control (Menu)
+Comment=Launch ZRAM control options (start, stop, status)
+Exec=toggle-zram-gui.sh
+Icon=utilities-system-monitor
+Terminal=false
+Categories=System;Utility;
+Keywords=zram;swap;memory;performance;control;
+StartupNotify=false
+Hidden=false
+


### PR DESCRIPTION
This setup allows having Zram started right from the boot, once the UI session starts. If for any reason the user who has administration rights (with sudo) wants to stop zram, a menu in the *Applications / System* tools is available to stop and restart it at will.
Wondering what [Zram](https://en.wikipedia.org/wiki/Zram) might be? This is a kernel module and it helps when not having enough RAM (system memory) in a computer.
For now it is built and tested in a Bento antiX 32bits build from antiX 32bits Core with SysvInit.

