### PR TITLE
Fixed Bento antiX desktop background

### DIFF
--- a/etc/skel/.config/pcmanfm/default/desktop-items-0.conf
+++ b/etc/skel/.config/pcmanfm/default/desktop-items-0.conf
@@ -1,7 +1,7 @@
 [*]
 wallpaper_mode=stretch
 wallpaper_common=1
-wallpaper=/usr/share/bento/backgrounds/wallpaper-blue-flowers-bento.jpg
+wallpaper=/usr/share/bento/backgrounds/bg_bento-antix_i486.jpg
 desktop_bg=#092042
 desktop_fg=#ffffff
 desktop_shadow=#092042


### PR DESCRIPTION
The background was not the right one so there was no wallpaper when the session started.