### PR TITLE
Changed `pkexec` for `gksu -S` - fits antiX better

### DIFF
--- a/etc/skel/.config/openbox/lang/menu.xml-de
+++ b/etc/skel/.config/openbox/lang/menu.xml-de
@@ -87,7 +87,7 @@
 		<item icon="/usr/share/icons/hicolor/256x256/apps/synaptic.png" label="Synaptic">
 			<action name="Execute">
 				<execute>
-					pkexec synaptic
+					gksu -S synaptic
 				</execute>
 			</action>
 		</item>

--- a/etc/skel/.config/openbox/lang/menu.xml-en
+++ b/etc/skel/.config/openbox/lang/menu.xml-en
@@ -86,7 +86,7 @@
 		<item icon="/usr/share/icons/hicolor/256x256/apps/synaptic.png" label="Synaptic">
 			<action name="Execute">
 				<execute>
-					pkexec synaptic
+					gksu -S synaptic
 				</execute>
 			</action>
 		</item>

--- a/etc/skel/.config/openbox/lang/menu.xml-fr
+++ b/etc/skel/.config/openbox/lang/menu.xml-fr
@@ -91,7 +91,7 @@
 		<item icon="/usr/share/icons/hicolor/256x256/apps/synaptic.png" label="Synaptic">
 			<action name="Execute">
 				<execute>
-					pkexec synaptic
+					gksu -S synaptic
 				</execute>
 			</action>
 		</item>


### PR DESCRIPTION
The openbox menu.xml-* files needed to be fixed to be able to launch the Synaptic shortcut from the menus.