### PR TITLE
Added zstd to packages list to be installed

### DIFF
--- a/Packages/Install-packages-into-antiX-core.sh
+++ b/Packages/Install-packages-into-antiX-core.sh
@@ -70,7 +70,8 @@ apt install -y --install-recommends \
 	iso-snapshot-cli \
 	isolinux \
 	l3afpad \
-	linux-libc-dev
+	linux-libc-dev \
+	zstd
 echo "antiX specific packages group installed successfully."
 
 # --- Bento main ---


### PR DESCRIPTION
zstd can be needed when using ISO-Snapshot to rebuild the system into a distributable ISO. It is one of the possible options for the compression of the squashfs.
