### PR TITLE
The files allow using `sudo` as the default

### DIFF
--- a/etc/skel/.gconf/apps/gksu/%gconf.xml
+++ b/etc/skel/.gconf/apps/gksu/%gconf.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<gconf>
+	<entry name="display-no-pass-info" mtime="1752691316" type="bool" value="false"/>
+	<entry name="sudo-mode" mtime="1752673770" type="bool" value="true"/>
+</gconf>


### PR DESCRIPTION
gksu-properties allows choosing between *su* and *sudo* as the default, for administration tasks when using **gksu**. 

*sudo* was chosen, thus making it optional to create a root account with its password when installing the distribution. 

The resulting files under `~/.gconf` are now being provided for all users.
