### PR TITLE
Storing live launchers and post-install removal

### DIFF
--- a/usr/local/share/excludes/README.txt
+++ b/usr/local/share/excludes/README.txt
@@ -1,0 +1,8 @@
+The static-root-delete.list file belongs to the antix-libs package.
+
+This paragraph was added at the end of the file to prevent the related
+scripts to be launched after the system has been installed.
+#----------------------------------------------------------------------
+# *.desktop launchers to remove from /etc/xdg/autostart at post-install
+(…)
+# ---------------------------------------------------------------------

--- a/usr/local/share/excludes/static-root-delete.list
+++ b/usr/local/share/excludes/static-root-delete.list
@@ -1,0 +1,22 @@
+#--------------------------------------------------------------------
+# static-root-delete.list
+#
+# The files listed here will be deleted at shutdown on live systems
+# when static root persistence is enabled.
+#
+# The original list is available in static-root-delete.orig.
+#--------------------------------------------------------------------
+
+/tmp/*
+/tmp/.[^.]*
+/var/cache/apt/*.bin
+/var/cache/apt/archives/*.deb
+/var/cache/debconf/*-old
+/var/lib/apt/lists/*
+/var/lib/dpkg/*-old
+#----------------------------------------------------------------------
+# *.desktop launchers to remove from /etc/xdg/autostart at post-install
+/etc/xdg/autostart/cp-minstall-launcher.desktop
+/etc/xdg/autostart/fix-network-live.desktop
+/etc/xdg/autostart/welcome-information.desktop
+# ---------------------------------------------------------------------

--- a/usr/share/bento/autostart/README.txt
+++ b/usr/share/bento/autostart/README.txt
@@ -1,0 +1,4 @@
+These desktop files are meant for live Bento antiX respins. They will be
+removed from /etc/xdg/autostart in post-install, and can be reinstalled
+there before remastering, or snapshotting.
+

--- a/usr/share/bento/autostart/cp-minstall-launcher.desktop
+++ b/usr/share/bento/autostart/cp-minstall-launcher.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Encoding=UTF-8
+Version=1.0
+Type=Application
+Name=Copy launcher for antiX installer
+Name[fr]=Copier le lanceur de l'installeur antiX
+Comment=Script install launcher copy
+Comment[fr]=Copie du lanceur de l'installeur antiX
+TryExec=bento-antix.desktop.sh
+Exec=bento-antix.desktop.sh
+StartupNotify=false
+Terminal=false
+Hidden=false
+

--- a/usr/share/bento/autostart/fix-network-live.desktop
+++ b/usr/share/bento/autostart/fix-network-live.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Encoding=UTF-8
+Version=1.0
+Type=Application
+Name=Copy launcher for antiX installer
+Name[fr]=Copier le lanceur de l'installeur antiX
+Comment=Script install launcher copy
+Comment[fr]=Copie du lanceur de l'installeur antiX
+TryExec=bento-antix.desktop.sh
+Exec=bento-antix.desktop.sh
+StartupNotify=false
+Terminal=false
+Hidden=false

--- a/usr/share/bento/autostart/welcome-information.desktop
+++ b/usr/share/bento/autostart/welcome-information.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Encoding=UTF-8
+Version=1.0
+Type=Application
+Comment=Creates an "INFORMATION.TXT" file on the live desktop
+Comment[fr]=Crée un fichier "INFORMATION.TXT" sur le bureau live
+Comment=Display the installation welcome message on the desktop
+Comment[fr]=Affiche le message de bienvenue d'installation sur le bureau
+Exec=welcome.sh
+StartupNotify=false
+Terminal=false


### PR DESCRIPTION
1. We need to remove 3 desktop launchers from /etc/xdg/autostart when the system has finished installing
2. We need to keep a copy of these files to reuse them in future new respins
3. The post removal is done in an exclude file from the antix-libs package and added to this repos