### PR TITLE
added radeon to get modules loaded into initrd

### DIFF
--- a/etc/initramfs-tools/modules
+++ b/etc/initramfs-tools/modules
@@ -1,0 +1,13 @@
+# List of modules that you want to include in your initramfs.
+# They will be loaded at boot time in the order below.
+#
+# Syntax:  module_name [args ...]
+#
+# You must run update-initramfs(8) to effect this change.
+#
+# Examples:
+#
+# raid1
+# sd_mod
+radeon
+


### PR DESCRIPTION
HD Radeon 7450 Caicos driver wasn't loaded at boot. Thanks to _radeon_ added in the modules file, and initramfs-update invoked, now all available radeon modules are available in the initrd file.